### PR TITLE
Use git hash for cache busting instead of static version

### DIFF
--- a/build.mjs
+++ b/build.mjs
@@ -1,8 +1,12 @@
 import { build } from "esbuild";
 import { cpSync, mkdirSync } from "fs";
-import { execSync } from "child_process";
+import { promisify } from "node:util";
+import { exec as execCallback, execSync } from "node:child_process";
 
-const gitHash = execSync("git rev-parse HEAD").toString().trim();
+const exec = promisify(execCallback);
+
+const { stdout } = await exec("git rev-parse HEAD");
+const gitHash = stdout.trim();
 
 await build({
   entryPoints: ["src/lambda.tsx"],

--- a/build.mjs
+++ b/build.mjs
@@ -2,6 +2,8 @@ import { build } from "esbuild";
 import { cpSync, mkdirSync } from "fs";
 import { execSync } from "child_process";
 
+const gitHash = execSync("git rev-parse --short HEAD").toString().trim();
+
 await build({
   entryPoints: ["src/lambda.tsx"],
   bundle: true,
@@ -11,6 +13,9 @@ await build({
   outfile: "dist/index.mjs",
   banner: {
     js: "import { createRequire } from 'module'; const require = createRequire(import.meta.url);",
+  },
+  define: {
+    __GIT_HASH__: JSON.stringify(gitHash),
   },
 });
 

--- a/build.mjs
+++ b/build.mjs
@@ -2,7 +2,7 @@ import { build } from "esbuild";
 import { cpSync, mkdirSync } from "fs";
 import { execSync } from "child_process";
 
-const gitHash = execSync("git rev-parse --short HEAD").toString().trim();
+const gitHash = execSync("git rev-parse HEAD").toString().trim();
 
 await build({
   entryPoints: ["src/lambda.tsx"],

--- a/src/views/layout.tsx
+++ b/src/views/layout.tsx
@@ -1,3 +1,5 @@
+declare const __GIT_HASH__: string | undefined;
+
 export const Layout = ({ children }: { children: any }) => (
   <html lang="en">
     <head>
@@ -12,7 +14,7 @@ export const Layout = ({ children }: { children: any }) => (
       <meta name="twitter:title" content="utgw.net" />
       <meta name="twitter:description" content="utgw.net" />
       <meta name="format-detection" content="telephone=no" />
-      <link rel="stylesheet" href="/styles/main.css?v=20260406" />
+      <link rel="stylesheet" href={`/styles/main.css?v=${__GIT_HASH__ ?? "dev"}`} />
     </head>
     <body>{children}</body>
   </html>

--- a/src/views/layout.tsx
+++ b/src/views/layout.tsx
@@ -14,7 +14,10 @@ export const Layout = ({ children }: { children: any }) => (
       <meta name="twitter:title" content="utgw.net" />
       <meta name="twitter:description" content="utgw.net" />
       <meta name="format-detection" content="telephone=no" />
-      <link rel="stylesheet" href={`/styles/main.css?v=${__GIT_HASH__ ?? "dev"}`} />
+      <link
+        rel="stylesheet"
+        href={`/styles/main.css?v=${typeof __GIT_HASH__ !== "undefined" ? __GIT_HASH__ : "dev"}`}
+      />
     </head>
     <body>{children}</body>
   </html>


### PR DESCRIPTION
## Summary
Replace the static version string in the stylesheet link with a dynamic git hash, enabling automatic cache busting based on the current commit rather than manual version updates.

## Key Changes
- Modified `build.mjs` to capture the current git commit hash during the build process
- Added the git hash as a build-time constant (`__GIT_HASH__`) via esbuild's `define` option
- Updated `src/views/layout.tsx` to use the git hash for stylesheet cache busting instead of the hardcoded version string `20260406`
- Falls back to `"dev"` when the git hash is unavailable (e.g., during development)

## Implementation Details
- Uses `git rev-parse HEAD` to retrieve the current commit hash at build time
- The hash is injected as a global constant that can be referenced in the source code
- The stylesheet URL now dynamically includes the git hash as a query parameter, ensuring browsers fetch fresh CSS on every commit

https://claude.ai/code/session_017wrz1tnCcis8yMMDx9qcef