### PR TITLE
Configure Dependabot grouping for npm dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,15 @@ updates:
       - "dependencies"
     cooldown:
       default-days: 7
+    groups:
+      oxlint:
+        patterns:
+          - "oxlint"
+          - "oxfmt"
+      tailwindcss:
+        patterns:
+          - "tailwindcss"
+          - "@tailwindcss/*"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
## Summary
This change configures Dependabot to group related npm package updates together, reducing the number of separate pull requests created for dependency updates.

## Key Changes
- Added dependency grouping configuration for npm packages in `.github/dependabot.yml`
- Created `oxlint` group to bundle updates for `oxlint` and `oxfmt` packages
- Created `tailwindcss` group to bundle updates for `tailwindcss` and all `@tailwindcss/*` scoped packages

## Details
By grouping related dependencies, Dependabot will create a single pull request when multiple packages in the same group have updates available, rather than creating separate PRs for each package. This helps reduce notification noise and makes it easier to review and merge related dependency updates together.

https://claude.ai/code/session_018ECkTAhnseTAnBSbXDJFVK