### PR TITLE
Add concurrency control to CI/CD workflow

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -26,7 +26,6 @@ jobs:
   e2e:
     timeout-minutes: 60
     runs-on: ubuntu-latest
-    needs: [ci]
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6.4.0

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -6,6 +6,9 @@ on:
       - master
 env:
   AWS_ROLE_ARN: arn:aws:iam::747582436141:role/utgw-net-deploy
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 permissions:
   id-token: write
   contents: read
@@ -23,6 +26,7 @@ jobs:
   e2e:
     timeout-minutes: 60
     runs-on: ubuntu-latest
+    needs: [ci]
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6.4.0


### PR DESCRIPTION
## Summary
Added concurrency configuration to the GitHub Actions CI/CD workflow to prevent multiple concurrent runs and optimize resource usage.

## Changes
- Added `concurrency` group configuration to the workflow that groups runs by workflow name and git reference
- Configured `cancel-in-progress` to automatically cancel in-progress runs on non-master branches, while allowing master branch runs to complete

## Details
This change ensures that:
- Only one workflow run executes at a time for a given branch
- Previous runs on feature branches are automatically cancelled when new commits are pushed, reducing unnecessary CI/CD resource consumption
- Master branch runs are allowed to complete without interruption for stability

https://claude.ai/code/session_01NQJffHTy7k1rKE16EsgHxy